### PR TITLE
docs: update README, add npm publish scripts and guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,27 +58,58 @@ solution = ik.solve(target_pose)
 
 ### JavaScript/WebAssembly Example
 
+```bash
+# Install from npm
+npm install urdfx
+```
+
 ```javascript
-import urdfx from './urdfx.js';
+const createUrdfxModule = require('urdfx');
 
 // Initialize WASM module
-const module = await urdfx();
+const urdfx = await createUrdfxModule();
 
-// Load robot
-const robot = module.Robot.fromURDF(urdfData);
+// Load robot from URDF string
+const urdfXml = `<?xml version="1.0"?>
+<robot name="my_robot">
+  <!-- Your URDF content -->
+</robot>`;
+
+const robot = urdfx.Robot.fromURDFString(urdfXml);
 
 // Compute forward kinematics
-const fk = new module.ForwardKinematics(robot);
+const fk = new urdfx.ForwardKinematics(robot);
 const pose = fk.compute([0.0, -1.57, 0.0, 0.0, 0.0, 0.0]);
 
 // Solve inverse kinematics
-const ik = new module.IKSolver(robot);
-const solution = ik.solve(targetPose);
+const ik = new urdfx.SQPIKSolver(robot);
+const targetPose = {
+  position: [0.5, 0.0, 0.5],
+  quaternion: [1.0, 0.0, 0.0, 0.0]
+};
+const solution = ik.solve(targetPose, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]);
+
+// Clean up
+ik.dispose();
+fk.dispose();
+robot.dispose();
 ```
 
 ## Installation
 
-### Prerequisites
+### npm Package (WebAssembly)
+
+The easiest way to use urdfx in JavaScript/TypeScript projects:
+
+```bash
+npm install urdfx
+```
+
+Available on npm: https://www.npmjs.com/package/urdfx
+
+### Building from Source
+
+#### Prerequisites
 
 - C++20 compatible compiler (GCC 10+, Clang 12+, MSVC 19.29+ / Visual Studio 2019 16.11+)
 - CMake 3.20 or later
@@ -238,6 +269,10 @@ urdfx/
 │
 ├── cmake/                      # CMake modules
 ├── scripts/                    # Build and setup scripts
+│   ├── build-wasm.ps1/sh      # Build WASM bindings
+│   ├── publish-npm.ps1/sh     # Publish to npm (Windows/Linux)
+│   ├── setup.ps1/sh           # Development environment setup
+│   └── PUBLISH_README.md      # npm publishing guide
 ├── openspec/                   # OpenSpec specifications
 └── CMakeLists.txt              # Root CMake configuration
 ```

--- a/scripts/PUBLISH_README.md
+++ b/scripts/PUBLISH_README.md
@@ -1,0 +1,276 @@
+# npm Publishing Scripts
+
+这个目录包含用于将 urdfx WASM 绑定发布到 npm 的脚本。
+
+## 脚本文件
+
+### Windows
+- **`publish-npm.ps1`** - Windows PowerShell 发布脚本
+
+### Linux/macOS
+- **`publish-npm.sh`** - Bash 发布脚本
+
+## 使用方法
+
+### Windows (PowerShell)
+
+```powershell
+# 基本发布（会提示确认）
+.\scripts\publish-npm.ps1
+
+# 指定版本号
+.\scripts\publish-npm.ps1 -Version "1.0.1"
+
+# 干运行（不实际发布）
+.\scripts\publish-npm.ps1 -DryRun
+
+# 跳过构建步骤（如果已经构建过）
+.\scripts\publish-npm.ps1 -SkipBuild
+
+# 组合使用
+.\scripts\publish-npm.ps1 -Version "1.0.2" -DryRun
+```
+
+### Linux/macOS (Bash)
+
+首先确保脚本有执行权限：
+```bash
+chmod +x scripts/publish-npm.sh
+```
+
+然后运行：
+```bash
+# 基本发布（会提示确认）
+./scripts/publish-npm.sh
+
+# 指定版本号
+./scripts/publish-npm.sh --version "1.0.1"
+
+# 干运行（不实际发布）
+./scripts/publish-npm.sh --dry-run
+
+# 跳过构建步骤（如果已经构建过）
+./scripts/publish-npm.sh --skip-build
+
+# 组合使用
+./scripts/publish-npm.sh --version "1.0.2" --dry-run
+```
+
+## 脚本功能
+
+这些脚本会自动完成以下步骤：
+
+1. ✅ **检查 npm 认证** - 确认你已登录 npm
+2. ✅ **构建 WASM 模块** - 调用 `build-wasm.ps1/sh` 编译 WASM
+3. ✅ **验证构建产物** - 检查 urdfx.js 和 urdfx.wasm 是否存在
+4. ✅ **准备发布目录** - 创建 dist 目录并复制所有必需文件
+5. ✅ **生成 package.json** - 创建或更新包配置文件
+6. ✅ **预览包内容** - 运行 `npm pack --dry-run` 查看将发布的内容
+7. ✅ **发布到 npm** - 执行 `npm publish`（需要确认）
+8. ✅ **清理说明** - 提示清理临时文件
+
+## 命令行选项
+
+### Windows PowerShell
+
+| 选项 | 说明 |
+|------|------|
+| `-Version <版本号>` | 设置包版本号（如 "1.0.1"） |
+| `-DryRun` | 干运行模式，不实际发布 |
+| `-SkipBuild` | 跳过 WASM 构建步骤 |
+| `-SkipTests` | 跳过测试步骤（保留用于未来） |
+
+### Linux/macOS Bash
+
+| 选项 | 说明 |
+|------|------|
+| `--version <版本号>` | 设置包版本号（如 "1.0.1"） |
+| `--dry-run` | 干运行模式，不实际发布 |
+| `--skip-build` | 跳过 WASM 构建步骤 |
+| `--skip-tests` | 跳过测试步骤（保留用于未来） |
+| `-h, --help` | 显示帮助信息 |
+
+## 发布前检查清单
+
+在运行发布脚本之前，请确保：
+
+- [ ] 已登录 npm：`npm login`
+- [ ] 已提交所有代码更改
+- [ ] 已更新 CHANGELOG（如果有）
+- [ ] 已测试 WASM 构建正常工作
+- [ ] 已确认要发布的版本号
+
+## 发布流程示例
+
+### 首次发布
+
+```powershell
+# Windows
+.\scripts\publish-npm.ps1 -Version "1.0.0"
+```
+
+```bash
+# Linux/macOS
+./scripts/publish-npm.sh --version "1.0.0"
+```
+
+### 发布补丁版本
+
+```powershell
+# Windows - 先干运行测试
+.\scripts\publish-npm.ps1 -Version "1.0.1" -DryRun
+
+# 确认无误后正式发布
+.\scripts\publish-npm.ps1 -Version "1.0.1"
+```
+
+```bash
+# Linux/macOS - 先干运行测试
+./scripts/publish-npm.sh --version "1.0.1" --dry-run
+
+# 确认无误后正式发布
+./scripts/publish-npm.sh --version "1.0.1"
+```
+
+### 快速重新发布（已构建过）
+
+```powershell
+# Windows
+.\scripts\publish-npm.ps1 -Version "1.0.2" -SkipBuild
+```
+
+```bash
+# Linux/macOS
+./scripts/publish-npm.sh --version "1.0.2" --skip-build
+```
+
+## 发布后验证
+
+发布成功后，可以通过以下方式验证：
+
+```bash
+# 查看包信息
+npm view urdfx
+
+# 在新目录中测试安装
+mkdir test-install && cd test-install
+npm init -y
+npm install urdfx
+node -e "require('urdfx').then(m => console.log('✓ Package works!'))"
+```
+
+## 故障排除
+
+### 认证失败
+```
+✗ Not logged in to npm. Please run 'npm login' first.
+```
+**解决方案**：运行 `npm login` 并按提示登录
+
+### 构建失败
+```
+✗ WASM build failed
+```
+**解决方案**：
+1. 检查是否安装了 Emscripten
+2. 运行 `emsdk activate latest`
+3. 检查 CMake 和 C++ 编译器是否正常
+
+### 包名冲突
+```
+npm ERR! 403 Forbidden - PUT https://registry.npmjs.org/urdfx
+```
+**解决方案**：包名已被占用，需要更改 package.json 中的包名
+
+### 版本冲突
+```
+npm ERR! 403 Forbidden - You cannot publish over the previously published version
+```
+**解决方案**：需要使用更高的版本号
+
+## 目录结构
+
+发布脚本会创建以下目录结构：
+
+```
+bindings/wasm/dist/
+├── urdfx.js          # WASM 加载器和绑定
+├── urdfx.wasm        # WASM 二进制文件
+├── urdfx.d.ts        # TypeScript 类型定义
+├── README.md         # 包文档
+├── LICENSE           # MIT 许可证
+├── package.json      # npm 包配置
+└── .npmignore        # npm 忽略文件
+```
+
+## 清理
+
+发布后，dist 目录可以安全删除：
+
+```powershell
+# Windows
+Remove-Item -Recurse -Force bindings\wasm\dist
+```
+
+```bash
+# Linux/macOS
+rm -rf bindings/wasm/dist
+```
+
+构建产物也可以清理：
+
+```powershell
+# Windows
+Remove-Item -Recurse -Force build-wasm
+```
+
+```bash
+# Linux/macOS
+rm -rf build-wasm
+```
+
+## 版本管理建议
+
+- **补丁版本** (1.0.x)：错误修复、小改进
+- **次要版本** (1.x.0)：新功能、向后兼容
+- **主要版本** (x.0.0)：破坏性更改
+
+遵循[语义化版本](https://semver.org/lang/zh-CN/)规范。
+
+## 自动化提示
+
+可以将这些脚本集成到 CI/CD 流程中：
+
+### GitHub Actions 示例
+
+```yaml
+name: Publish to npm
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install Emscripten
+        run: |
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk
+          ./emsdk install latest
+          ./emsdk activate latest
+      - name: Publish to npm
+        run: ./scripts/publish-npm.sh --version ${{ github.event.release.tag_name }} --skip-tests
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+## 支持
+
+如有问题，请提交 Issue：https://github.com/Daoming-Chen/urdfx/issues

--- a/scripts/publish-npm.ps1
+++ b/scripts/publish-npm.ps1
@@ -1,0 +1,292 @@
+# Publish urdfx WASM bindings to npm
+# This script builds the WASM module and publishes it to npm
+
+param(
+    [string]$Version = "",
+    [switch]$DryRun = $false,
+    [switch]$SkipBuild = $false,
+    [switch]$SkipTests = $false
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "`n===> $Message" -ForegroundColor Cyan
+}
+
+function Write-Success {
+    param([string]$Message)
+    Write-Host "✓ $Message" -ForegroundColor Green
+}
+
+function Write-Error-Custom {
+    param([string]$Message)
+    Write-Host "✗ $Message" -ForegroundColor Red
+}
+
+# Get script directory and project root
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+$WasmDir = Join-Path $ProjectRoot "bindings\wasm"
+$DistDir = Join-Path $WasmDir "dist"
+
+Write-Host "╔════════════════════════════════════════╗" -ForegroundColor Cyan
+Write-Host "║   urdfx npm Publisher for Windows     ║" -ForegroundColor Cyan
+Write-Host "╚════════════════════════════════════════╝" -ForegroundColor Cyan
+
+# Step 1: Check npm login status
+Write-Step "Checking npm authentication..."
+$npmUser = npm whoami 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Error-Custom "Not logged in to npm. Please run 'npm login' first."
+    exit 1
+}
+Write-Success "Logged in as: $npmUser"
+
+# Step 2: Build WASM module (unless skipped)
+if (-not $SkipBuild) {
+    Write-Step "Building WASM module..."
+    
+    $BuildScript = Join-Path $ScriptDir "build-wasm.ps1"
+    if (-not (Test-Path $BuildScript)) {
+        Write-Error-Custom "Build script not found: $BuildScript"
+        exit 1
+    }
+    
+    & $BuildScript
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error-Custom "WASM build failed"
+        exit 1
+    }
+    Write-Success "WASM build completed"
+} else {
+    Write-Step "Skipping WASM build (--SkipBuild specified)"
+}
+
+# Step 3: Verify build artifacts
+Write-Step "Verifying build artifacts..."
+$BuildWasmDir = Join-Path $ProjectRoot "build-wasm\wasm"
+$WasmJs = Join-Path $BuildWasmDir "urdfx.js"
+$WasmBinary = Join-Path $BuildWasmDir "urdfx.wasm"
+
+if (-not (Test-Path $WasmJs)) {
+    Write-Error-Custom "WASM JavaScript file not found: $WasmJs"
+    exit 1
+}
+if (-not (Test-Path $WasmBinary)) {
+    Write-Error-Custom "WASM binary file not found: $WasmBinary"
+    exit 1
+}
+Write-Success "Build artifacts verified"
+
+# Step 4: Prepare distribution directory
+Write-Step "Preparing distribution directory..."
+if (Test-Path $DistDir) {
+    Remove-Item -Recurse -Force $DistDir
+}
+New-Item -ItemType Directory -Path $DistDir -Force | Out-Null
+
+# Copy build artifacts
+Copy-Item $WasmJs $DistDir
+Copy-Item $WasmBinary $DistDir
+
+# Copy additional files
+$TypeDefs = Join-Path $WasmDir "urdfx.d.ts"
+$ReadmeSource = Join-Path $WasmDir "dist\README.md"
+$License = Join-Path $ProjectRoot "LICENSE"
+
+if (Test-Path $TypeDefs) {
+    Copy-Item $TypeDefs $DistDir
+} else {
+    Write-Error-Custom "TypeScript definitions not found: $TypeDefs"
+    exit 1
+}
+
+if (Test-Path $License) {
+    Copy-Item $License $DistDir
+} else {
+    Write-Error-Custom "LICENSE file not found: $License"
+    exit 1
+}
+
+# Create or verify README.md
+if (-not (Test-Path $ReadmeSource)) {
+    Write-Host "README.md not found, creating default..." -ForegroundColor Yellow
+    $ReadmeContent = @"
+# urdfx
+
+A modern WebAssembly robotics kinematics library providing URDF parsing, forward kinematics, Jacobian computation, and inverse kinematics solving.
+
+## Installation
+
+``````bash
+npm install urdfx
+``````
+
+## Quick Start
+
+``````javascript
+const createUrdfxModule = require('urdfx');
+
+(async () => {
+  const urdfx = await createUrdfxModule();
+  
+  const urdfXml = ``<?xml version="1.0"?>
+  <robot name="my_robot">
+    <!-- Your URDF content -->
+  </robot>``;
+  
+  const robot = urdfx.Robot.fromURDFString(urdfXml);
+  console.log('Robot:', robot.getName());
+  
+  robot.dispose();
+})();
+``````
+
+## Documentation
+
+For full documentation, visit: https://github.com/Daoming-Chen/urdfx
+
+## License
+
+MIT
+"@
+    $ReadmeContent | Out-File -FilePath (Join-Path $DistDir "README.md") -Encoding utf8
+} else {
+    Copy-Item $ReadmeSource $DistDir
+}
+
+Write-Success "Distribution directory prepared"
+
+# Step 5: Create/update package.json
+Write-Step "Preparing package.json..."
+
+$PackageJsonPath = Join-Path $DistDir "package.json"
+
+# Read existing package.json or create new
+if (Test-Path $PackageJsonPath) {
+    $PackageJson = Get-Content $PackageJsonPath -Raw | ConvertFrom-Json
+} else {
+    $PackageJson = @{
+        name = "urdfx"
+        version = "1.0.0"
+        description = "A modern WebAssembly robotics kinematics library"
+        main = "urdfx.js"
+        types = "urdfx.d.ts"
+        type = "module"
+        files = @("urdfx.js", "urdfx.wasm", "urdfx.d.ts", "README.md", "LICENSE")
+        keywords = @("robotics", "kinematics", "urdf", "inverse-kinematics", "forward-kinematics", "jacobian", "webassembly", "wasm", "robot", "3d")
+        author = "urdfx contributors"
+        license = "MIT"
+        repository = @{
+            type = "git"
+            url = "https://github.com/Daoming-Chen/urdfx.git"
+        }
+        bugs = @{
+            url = "https://github.com/Daoming-Chen/urdfx/issues"
+        }
+        homepage = "https://github.com/Daoming-Chen/urdfx#readme"
+        engines = @{
+            node = ">=14.0.0"
+        }
+    }
+}
+
+# Update version if specified
+if ($Version) {
+    Write-Host "Updating version to: $Version" -ForegroundColor Yellow
+    $PackageJson.version = $Version
+}
+
+# Save package.json
+$PackageJson | ConvertTo-Json -Depth 10 | Out-File -FilePath $PackageJsonPath -Encoding utf8
+Write-Success "package.json prepared (version: $($PackageJson.version))"
+
+# Step 6: Create .npmignore
+$NpmIgnorePath = Join-Path $DistDir ".npmignore"
+$NpmIgnoreContent = @"
+# Test files
+*.test.js
+*.test.cjs
+test.js
+test.cjs
+check.cjs
+
+# Build files
+CMakeLists.txt
+cmake/
+src/
+
+# Development files
+.gitignore
+.git/
+.vscode/
+.cursor/
+
+# Documentation source
+docs/
+
+# Node modules
+node_modules/
+"@
+$NpmIgnoreContent | Out-File -FilePath $NpmIgnorePath -Encoding utf8
+
+Write-Success "Distribution files prepared"
+
+# Step 7: Run npm pack (dry run preview)
+Write-Step "Previewing package contents..."
+Push-Location $DistDir
+try {
+    npm pack --dry-run
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error-Custom "npm pack preview failed"
+        exit 1
+    }
+} finally {
+    Pop-Location
+}
+
+# Step 8: Publish to npm
+if ($DryRun) {
+    Write-Step "Performing dry run publish..."
+    Push-Location $DistDir
+    try {
+        npm publish --dry-run
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error-Custom "npm publish dry run failed"
+            exit 1
+        }
+        Write-Success "Dry run completed successfully"
+        Write-Host "`nTo publish for real, run without --DryRun flag" -ForegroundColor Yellow
+    } finally {
+        Pop-Location
+    }
+} else {
+    Write-Host "`n⚠️  Ready to publish urdfx@$($PackageJson.version) to npm" -ForegroundColor Yellow
+    Write-Host "Press Enter to continue or Ctrl+C to cancel..." -ForegroundColor Yellow
+    Read-Host
+    
+    Write-Step "Publishing to npm..."
+    Push-Location $DistDir
+    try {
+        npm publish
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error-Custom "npm publish failed"
+            exit 1
+        }
+        
+        Write-Host "`n╔════════════════════════════════════════╗" -ForegroundColor Green
+        Write-Host "║   Successfully published to npm! 🎉   ║" -ForegroundColor Green
+        Write-Host "╚════════════════════════════════════════╝" -ForegroundColor Green
+        Write-Host "`nPackage: urdfx@$($PackageJson.version)" -ForegroundColor Green
+        Write-Host "URL: https://www.npmjs.com/package/urdfx" -ForegroundColor Cyan
+        Write-Host "`nInstall with: npm install urdfx" -ForegroundColor Cyan
+    } finally {
+        Pop-Location
+    }
+}
+
+# Step 9: Clean up (optional)
+Write-Host "`nDistribution files are in: $DistDir" -ForegroundColor Cyan
+Write-Host "You can safely delete this directory after publishing." -ForegroundColor Gray

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -1,0 +1,308 @@
+#!/bin/bash
+# Publish urdfx WASM bindings to npm
+# This script builds the WASM module and publishes it to npm
+
+set -e
+
+# Color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Default values
+VERSION=""
+DRY_RUN=false
+SKIP_BUILD=false
+SKIP_TESTS=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --version)
+            VERSION="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --skip-build)
+            SKIP_BUILD=true
+            shift
+            ;;
+        --skip-tests)
+            SKIP_TESTS=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --version VERSION    Set package version"
+            echo "  --dry-run           Perform dry run without publishing"
+            echo "  --skip-build        Skip WASM build step"
+            echo "  --skip-tests        Skip test execution"
+            echo "  -h, --help          Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+function write_step {
+    echo -e "\n${CYAN}===> $1${NC}"
+}
+
+function write_success {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+function write_error {
+    echo -e "${RED}✗ $1${NC}"
+}
+
+# Get script directory and project root
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
+WASM_DIR="$PROJECT_ROOT/bindings/wasm"
+DIST_DIR="$WASM_DIR/dist"
+
+echo -e "${CYAN}╔════════════════════════════════════════╗${NC}"
+echo -e "${CYAN}║   urdfx npm Publisher for Linux/Mac   ║${NC}"
+echo -e "${CYAN}╚════════════════════════════════════════╝${NC}"
+
+# Step 1: Check npm login status
+write_step "Checking npm authentication..."
+if ! NPM_USER=$(npm whoami 2>/dev/null); then
+    write_error "Not logged in to npm. Please run 'npm login' first."
+    exit 1
+fi
+write_success "Logged in as: $NPM_USER"
+
+# Step 2: Build WASM module (unless skipped)
+if [ "$SKIP_BUILD" = false ]; then
+    write_step "Building WASM module..."
+    
+    BUILD_SCRIPT="$SCRIPT_DIR/build-wasm.sh"
+    if [ ! -f "$BUILD_SCRIPT" ]; then
+        write_error "Build script not found: $BUILD_SCRIPT"
+        exit 1
+    fi
+    
+    bash "$BUILD_SCRIPT"
+    write_success "WASM build completed"
+else
+    write_step "Skipping WASM build (--skip-build specified)"
+fi
+
+# Step 3: Verify build artifacts
+write_step "Verifying build artifacts..."
+BUILD_WASM_DIR="$PROJECT_ROOT/build-wasm/wasm"
+WASM_JS="$BUILD_WASM_DIR/urdfx.js"
+WASM_BINARY="$BUILD_WASM_DIR/urdfx.wasm"
+
+if [ ! -f "$WASM_JS" ]; then
+    write_error "WASM JavaScript file not found: $WASM_JS"
+    exit 1
+fi
+if [ ! -f "$WASM_BINARY" ]; then
+    write_error "WASM binary file not found: $WASM_BINARY"
+    exit 1
+fi
+write_success "Build artifacts verified"
+
+# Step 4: Prepare distribution directory
+write_step "Preparing distribution directory..."
+rm -rf "$DIST_DIR"
+mkdir -p "$DIST_DIR"
+
+# Copy build artifacts
+cp "$WASM_JS" "$DIST_DIR/"
+cp "$WASM_BINARY" "$DIST_DIR/"
+
+# Copy additional files
+TYPE_DEFS="$WASM_DIR/urdfx.d.ts"
+README_SOURCE="$WASM_DIR/dist/README.md"
+LICENSE="$PROJECT_ROOT/LICENSE"
+
+if [ -f "$TYPE_DEFS" ]; then
+    cp "$TYPE_DEFS" "$DIST_DIR/"
+else
+    write_error "TypeScript definitions not found: $TYPE_DEFS"
+    exit 1
+fi
+
+if [ -f "$LICENSE" ]; then
+    cp "$LICENSE" "$DIST_DIR/"
+else
+    write_error "LICENSE file not found: $LICENSE"
+    exit 1
+fi
+
+# Create or verify README.md
+if [ ! -f "$README_SOURCE" ]; then
+    echo -e "${YELLOW}README.md not found, creating default...${NC}"
+    cat > "$DIST_DIR/README.md" << 'EOF'
+# urdfx
+
+A modern WebAssembly robotics kinematics library providing URDF parsing, forward kinematics, Jacobian computation, and inverse kinematics solving.
+
+## Installation
+
+```bash
+npm install urdfx
+```
+
+## Quick Start
+
+```javascript
+const createUrdfxModule = require('urdfx');
+
+(async () => {
+  const urdfx = await createUrdfxModule();
+  
+  const urdfXml = `<?xml version="1.0"?>
+  <robot name="my_robot">
+    <!-- Your URDF content -->
+  </robot>`;
+  
+  const robot = urdfx.Robot.fromURDFString(urdfXml);
+  console.log('Robot:', robot.getName());
+  
+  robot.dispose();
+})();
+```
+
+## Documentation
+
+For full documentation, visit: https://github.com/Daoming-Chen/urdfx
+
+## License
+
+MIT
+EOF
+else
+    cp "$README_SOURCE" "$DIST_DIR/"
+fi
+
+write_success "Distribution directory prepared"
+
+# Step 5: Create/update package.json
+write_step "Preparing package.json..."
+
+PACKAGE_JSON_PATH="$DIST_DIR/package.json"
+
+# Create package.json
+cat > "$PACKAGE_JSON_PATH" << EOF
+{
+  "name": "urdfx",
+  "version": "${VERSION:-1.0.0}",
+  "description": "A modern WebAssembly robotics kinematics library providing URDF parsing, forward kinematics, Jacobian computation, and inverse kinematics solving",
+  "main": "urdfx.js",
+  "types": "urdfx.d.ts",
+  "type": "module",
+  "files": [
+    "urdfx.js",
+    "urdfx.wasm",
+    "urdfx.d.ts",
+    "README.md",
+    "LICENSE"
+  ],
+  "keywords": [
+    "robotics",
+    "kinematics",
+    "urdf",
+    "inverse-kinematics",
+    "forward-kinematics",
+    "jacobian",
+    "webassembly",
+    "wasm",
+    "robot",
+    "3d"
+  ],
+  "author": "urdfx contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Daoming-Chen/urdfx.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Daoming-Chen/urdfx/issues"
+  },
+  "homepage": "https://github.com/Daoming-Chen/urdfx#readme",
+  "engines": {
+    "node": ">=14.0.0"
+  }
+}
+EOF
+
+PACKAGE_VERSION=$(grep -o '"version": "[^"]*"' "$PACKAGE_JSON_PATH" | cut -d'"' -f4)
+write_success "package.json prepared (version: $PACKAGE_VERSION)"
+
+# Step 6: Create .npmignore
+cat > "$DIST_DIR/.npmignore" << 'EOF'
+# Test files
+*.test.js
+*.test.cjs
+test.js
+test.cjs
+check.cjs
+
+# Build files
+CMakeLists.txt
+cmake/
+src/
+
+# Development files
+.gitignore
+.git/
+.vscode/
+.cursor/
+
+# Documentation source
+docs/
+
+# Node modules
+node_modules/
+EOF
+
+write_success "Distribution files prepared"
+
+# Step 7: Run npm pack (dry run preview)
+write_step "Previewing package contents..."
+cd "$DIST_DIR"
+npm pack --dry-run
+
+# Step 8: Publish to npm
+if [ "$DRY_RUN" = true ]; then
+    write_step "Performing dry run publish..."
+    cd "$DIST_DIR"
+    npm publish --dry-run
+    write_success "Dry run completed successfully"
+    echo -e "\n${YELLOW}To publish for real, run without --dry-run flag${NC}"
+else
+    echo -e "\n${YELLOW}⚠️  Ready to publish urdfx@$PACKAGE_VERSION to npm${NC}"
+    echo -e "${YELLOW}Press Enter to continue or Ctrl+C to cancel...${NC}"
+    read
+    
+    write_step "Publishing to npm..."
+    cd "$DIST_DIR"
+    npm publish
+    
+    echo -e "\n${GREEN}╔════════════════════════════════════════╗${NC}"
+    echo -e "${GREEN}║   Successfully published to npm! 🎉   ║${NC}"
+    echo -e "${GREEN}╚════════════════════════════════════════╝${NC}"
+    echo -e "\n${GREEN}Package: urdfx@$PACKAGE_VERSION${NC}"
+    echo -e "${CYAN}URL: https://www.npmjs.com/package/urdfx${NC}"
+    echo -e "\n${CYAN}Install with: npm install urdfx${NC}"
+fi
+
+# Step 9: Clean up info
+echo -e "\n${CYAN}Distribution files are in: $DIST_DIR${NC}"
+echo -e "${NC}You can safely delete this directory after publishing.${NC}"


### PR DESCRIPTION
- Update main README with npm install and JS usage example
- Add scripts/publish-npm.ps1 (Windows) and scripts/publish-npm.sh (Linux/macOS)
- Add scripts/PUBLISH_README.md with detailed npm publishing instructions and troubleshooting
- Support one-click build, package, and publish of urdfx WASM to npm