### PR TITLE
Fix GitHub Pages configuration by adding enablement parameter

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
+        with:
+          enablement: true
 
       - name: Prepare deployment files
         run: |


### PR DESCRIPTION
Added `enablement: true` to the configure-pages action to automatically enable GitHub Pages for the repository during workflow execution. This resolves the "Get Pages site failed" error that occurs when Pages is not manually configured in repository settings.

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)